### PR TITLE
SPOI-4321

### DIFF
--- a/src/main/java/com/datatorrent/netlet/EventLoop.java
+++ b/src/main/java/com/datatorrent/netlet/EventLoop.java
@@ -27,7 +27,7 @@ import com.datatorrent.netlet.Listener.ServerListener;
  */
 public interface EventLoop
 {
-  void connect(final InetSocketAddress address, final Listener l);
+  void connect(final InetSocketAddress address, final ClientListener l);
 
   void disconnect(final ClientListener l);
 

--- a/src/main/java/com/datatorrent/netlet/Listener.java
+++ b/src/main/java/com/datatorrent/netlet/Listener.java
@@ -223,7 +223,7 @@ public interface Listener
     private void disconnect()
     {
       if (!key.isValid() || (key.interestOps() & SelectionKey.OP_WRITE) == 0) {
-        disconnected();
+        previous.disconnected();
         key.attach(null);
         try {
           key.channel().close();


### PR DESCRIPTION
added OP_READ to interest ops along with OP_CONNECT when connection is established. Occasionally channel was not selected after connection was established without OP_READ present in interestOps.
