### PR TITLE
An extra slot is needed to store the null delimiter when keys are retrieved

### DIFF
--- a/src/main/java/com/datatorrent/netlet/OptimizedEventLoop.java
+++ b/src/main/java/com/datatorrent/netlet/OptimizedEventLoop.java
@@ -37,22 +37,15 @@ public class OptimizedEventLoop extends DefaultEventLoop
 {
   private final static class SelectedSelectionKeySet extends AbstractSet<SelectionKey>
   {
-    private SelectionKey[] keys;
-    private int pos;
+    public SelectionKey[] keys;
+    public int pos;
 
     private SelectedSelectionKeySet(int size)
     {
       pos = 0;
       keys = new SelectionKey[size];
     }
-
-    private SelectionKey[] getKeys()
-    {
-      keys[pos] = null;
-      pos = 0;
-      return keys;
-    }
-
+    
     @Override
     public boolean add(SelectionKey key)
     {
@@ -60,7 +53,7 @@ public class OptimizedEventLoop extends DefaultEventLoop
         return false;
       }
       // An extra slot is needed to store the null delimiter when keys are retrieved
-      if (pos >= (keys.length - 1)) {
+      if (pos >= keys.length) {
         SelectionKey[] keys = new SelectionKey[this.keys.length << 1];
         System.arraycopy(this.keys, 0, keys, 0, this.keys.length);
         this.keys = keys;
@@ -158,14 +151,10 @@ public class OptimizedEventLoop extends DefaultEventLoop
             continue;
           }
 
-          SelectionKey[] selectedKeys = keys.getKeys();
-          for (int i = 0; alive; i++) {
-            sk = selectedKeys[i];
-            if (sk == null) {
-              break;
-            } else {
-              selectedKeys[i] = null;
-            }
+          SelectionKey[] selectedKeys = keys.keys;
+          while ((keys.pos > 0) && alive) {
+            --keys.pos;
+            sk = selectedKeys[keys.pos];
             if (!sk.isValid()) {
               continue;
             }

--- a/src/main/java/com/datatorrent/netlet/OptimizedEventLoop.java
+++ b/src/main/java/com/datatorrent/netlet/OptimizedEventLoop.java
@@ -59,7 +59,8 @@ public class OptimizedEventLoop extends DefaultEventLoop
       if (key == null) {
         return false;
       }
-      if (pos >= keys.length) {
+      // An extra slot is needed to store the null delimiter when keys are retrieved
+      if (pos >= (keys.length - 1)) {
         SelectionKey[] keys = new SelectionKey[this.keys.length << 1];
         System.arraycopy(this.keys, 0, keys, 0, this.keys.length);
         this.keys = keys;


### PR DESCRIPTION
If the number of selection keys is equal to the selection key array size in the selection key set the resize has to be triggered since an extra slot is needed for the terminating null selection key 
