### PR TITLE
createEventLoop factory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,18 @@
       <scope>test</scope>
       <type>jar</type>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-all</artifactId>
+      <version>5.0.0.Alpha2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.trove4j</groupId>
+      <artifactId>trove4j</artifactId>
+      <version>3.0.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <distributionManagement>

--- a/src/main/java/com/datatorrent/netlet/DefaultEventLoop.java
+++ b/src/main/java/com/datatorrent/netlet/DefaultEventLoop.java
@@ -36,6 +36,18 @@ import com.datatorrent.netlet.util.CircularBuffer;
  */
 public class DefaultEventLoop implements Runnable, EventLoop
 {
+  public static final String eventLoopPropertyName = "com.datatorrent.netlet.disableOptimizedEventLoop";
+  @SuppressWarnings("deprecation")
+  public static DefaultEventLoop createEventLoop(final String id) throws IOException
+  {
+    final String disableOptimizedEventLoop = System.getProperty(eventLoopPropertyName);
+    if (disableOptimizedEventLoop == null || disableOptimizedEventLoop.equalsIgnoreCase("true") || disableOptimizedEventLoop.equalsIgnoreCase("yes")) {
+      return new DefaultEventLoop(id);
+    } else {
+      return new OptimizedEventLoop(id);
+    }
+  }
+
   public final String id;
   protected final Selector selector;
   protected final CircularBuffer<Runnable> tasks;
@@ -43,6 +55,12 @@ public class DefaultEventLoop implements Runnable, EventLoop
   private int refCount;
   private Thread eventThread;
 
+  /**
+   * @deprecated use factory method {@link #createEventLoop(String)}
+   * @param id of the event loop
+   * @throws IOException
+   */
+  @Deprecated
   public DefaultEventLoop(String id) throws IOException
   {
     this.tasks = new CircularBuffer<Runnable>(1024, 5);

--- a/src/main/java/com/datatorrent/netlet/OptimizedEventLoop.java
+++ b/src/main/java/com/datatorrent/netlet/OptimizedEventLoop.java
@@ -97,7 +97,8 @@ public class OptimizedEventLoop extends DefaultEventLoop
     }
   }
 
-  public OptimizedEventLoop(String id) throws IOException
+  @SuppressWarnings("deprecation")
+  OptimizedEventLoop(String id) throws IOException
   {
     super(id);
     try {

--- a/src/test/java/com/datatorrent/benchmark/netlet/BenchmarkTcpClient.java
+++ b/src/test/java/com/datatorrent/benchmark/netlet/BenchmarkTcpClient.java
@@ -1,0 +1,196 @@
+/**
+ * Copyright (C) 2015 DataTorrent, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datatorrent.benchmark.netlet;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.SelectionKey;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.datatorrent.benchmark.util.Benchmarker;
+import com.datatorrent.netlet.AbstractClient;
+import com.datatorrent.netlet.DefaultEventLoop;
+import com.datatorrent.netlet.EventLoop;
+import com.datatorrent.netlet.OptimizedEventLoop;
+
+import static com.datatorrent.benchmark.util.SystemUtils.getBoolean;
+import static com.datatorrent.benchmark.util.SystemUtils.getInt;
+import static java.lang.Thread.sleep;
+
+/**
+ * <p>Netlet Coral Block based Benchmark Test Client</p>
+ * see: <a href="http://www.coralblocks.com/index.php/2014/04/coralreactor-vs-netty-performance-comparison">http://www.coralblocks.com/index.php/2014/04/coralreactor-vs-netty-performance-comparison</a>,
+ * <a href="http://stackoverflow.com/questions/23839437/what-are-the-netty-alternatives-for-high-performance-networking">http://stackoverflow.com/questions/23839437/what-are-the-netty-alternatives-for-high-performance-networking</a>,
+ * <a href="http://www.coralblocks.com/NettyBench.zip">http://www.coralblocks.com/NettyBench.zip</a> and
+ * <a href="https://groups.google.com/forum/#!topic/mechanical-sympathy/fhbyMnnxmaA">https://groups.google.com/forum/#!topic/mechanical-sympathy/fhbyMnnxmaA</a>
+ * <p>run: <code>java -server -verbose:gc -Xms1g -Xmx1g -XX:NewSize=512m -XX:MaxNewSize=512m -DdetailedBenchmarker=true -DmeasureGC=false -DmsgSize=256 -Dmessages=1000000  -DoptimizedEventLoop=true com.datatorrent.benchmark.netlet.BenchmarkTcpClient localhost 8080</code></p>
+ * <p>results=Iterations: 1000000 | Avg Time: 28.966 micros | Min Time: 11.0 micros | Max Time: 340.0 micros | 75% = [avg: 26.232 micros, max: 29.0 micros] | 90% = [avg: 27.38 micros, max: 37.0 micros] | 99% = [avg: 28.618 micros, max: 50.0 micros] | 99.9% = [avg: 28.907 micros, max: 80.0 micros] | 99.99% = [avg: 28.957 micros, max: 102.0 micros] | 99.999% = [avg: 28.964 micros, max: 133.0 micros]</p>
+ */
+public class BenchmarkTcpClient extends AbstractClient
+{
+  private static final Logger logger = LoggerFactory.getLogger(BenchmarkTcpClient.class);
+
+  private int count = 0;
+  private long start;
+  private boolean warmingUp = false;
+  private boolean benchmarking = false;
+  private long tsSent;
+  private final ByteBuffer readBuffer;
+  private final ByteBuffer sendBuffer;
+  private final int messages;
+  private final Benchmarker bench = Benchmarker.create();
+  private final DefaultEventLoop eventLoop;
+
+  private BenchmarkTcpClient(final String host, final int port) throws IOException, InterruptedException
+  {
+    super();
+    final int msgSize = getInt("msgSize", 256);
+    messages = getInt("messages", 1000000);
+    readBuffer = ByteBuffer.allocate(msgSize);
+    sendBuffer = ByteBuffer.allocate(msgSize);
+    eventLoop = getBoolean("optimizedEventLoop", false)?
+            new OptimizedEventLoop("OptimizedEventLoop") :new DefaultEventLoop("DefaultEventLoop");
+    final Thread eventLoopThread = eventLoop.start();
+    eventLoop.connect(new InetSocketAddress(host, port), this);
+    eventLoopThread.join();
+  }
+
+  @Override
+  public ByteBuffer buffer()
+  {
+    return readBuffer;
+  }
+
+  @Override
+  public void handleException(Exception e, EventLoop eventLoop)
+  {
+    logger.error("", e);
+    this.eventLoop.stop();
+  }
+
+  @Override
+  public void connected()
+  {
+    logger.info("Connected. Sending the first message.");
+    start = System.currentTimeMillis();
+    warmingUp = true;
+    benchmarking = false;
+    count = 0;
+    send(-1);
+  }
+
+  @Override
+  public void unregistered(SelectionKey key)
+  {
+    super.unregistered(key);
+    disconnected();
+  }
+
+  @Override
+  public void disconnected()
+  {
+    logger.info("Disconnected. Overall test time: {} millis", System.currentTimeMillis() - start);
+    bench.printResults(System.out);
+    eventLoop.stop();
+  }
+
+  @Override
+  public void read(int len)
+  {
+    if (readBuffer.position() != readBuffer.capacity()) {
+      logger.error("Read buffer position {} != capacity {}", readBuffer.position(), readBuffer.capacity());
+      eventLoop.disconnect(this);
+      return;
+    }
+
+    readBuffer.flip();
+    long tsReceived = readBuffer.getLong();
+    if (tsReceived < -2) {
+      logger.error("Received bad timestamp {}", tsReceived);
+      eventLoop.disconnect(this);
+      return;
+    } else if (tsReceived != tsSent) {
+      logger.error("Received bad timestamp {}. Sent timestamp {}", tsReceived, tsSent);
+      eventLoop.disconnect(this);
+      return;
+    } else if (tsReceived > 0) {
+      bench.measure(System.nanoTime() - tsReceived);
+    }
+    readBuffer.clear();
+
+    send();
+  }
+
+  private void send(final long tsSent)
+  {
+    this.tsSent = tsSent;
+    sendBuffer.putLong(tsSent);
+    while (sendBuffer.hasRemaining()) {
+      sendBuffer.put((byte)'x');
+    }
+    sendBuffer.flip();
+    try {
+      while (!send(sendBuffer.array())) {
+        sleep(5);
+      }
+      write();
+    } catch (Exception e) {
+      logger.error("", e);
+      eventLoop.disconnect(this);
+      return;
+    }
+    sendBuffer.clear();
+  }
+
+  private void send()
+  {
+    if (warmingUp) {
+      if (++count == messages) {
+        logger.info("Finished warming up! Sent {} messages in {} millis", count, System.currentTimeMillis() - start);
+        warmingUp = false;
+        benchmarking = true;
+        count = 0;
+        send(System.nanoTime());
+      } else {
+        send(0);
+      }
+    } else if (benchmarking) {
+      if (++count == messages) {
+        send(-2);
+        logger.info("Finished sending messages! Sent {} messages.", count);
+        eventLoop.disconnect(this);
+      } else {
+        send(System.nanoTime());
+      }
+    }
+  }
+
+  public static void main(String[] args)
+  {
+    String host = args[0];
+    int port = Integer.parseInt(args[1]);
+    try {
+      new BenchmarkTcpClient(host, port);
+    } catch (IOException e) {
+      logger.error("", e);
+    } catch (InterruptedException e) {
+      logger.error("", e);
+    }
+  }
+}

--- a/src/test/java/com/datatorrent/benchmark/netlet/BenchmarkTcpClient.java
+++ b/src/test/java/com/datatorrent/benchmark/netlet/BenchmarkTcpClient.java
@@ -39,7 +39,7 @@ import static java.lang.Thread.sleep;
  * <a href="http://stackoverflow.com/questions/23839437/what-are-the-netty-alternatives-for-high-performance-networking">http://stackoverflow.com/questions/23839437/what-are-the-netty-alternatives-for-high-performance-networking</a>,
  * <a href="http://www.coralblocks.com/NettyBench.zip">http://www.coralblocks.com/NettyBench.zip</a> and
  * <a href="https://groups.google.com/forum/#!topic/mechanical-sympathy/fhbyMnnxmaA">https://groups.google.com/forum/#!topic/mechanical-sympathy/fhbyMnnxmaA</a>
- * <p>run: <code>java -server -verbose:gc -Xms1g -Xmx1g -XX:NewSize=512m -XX:MaxNewSize=512m -DdetailedBenchmarker=true -DmeasureGC=false -DmsgSize=256 -Dmessages=1000000  -DoptimizedEventLoop=true com.datatorrent.benchmark.netlet.BenchmarkTcpClient localhost 8080</code></p>
+ * <p>run: <code>java -server -verbose:gc -Xms1g -Xmx1g -XX:NewSize=512m -XX:MaxNewSize=512m -DdetailedBenchmarker=true -DmeasureGC=false -DmsgSize=256 -Dmessages=1000000 com.datatorrent.benchmark.netlet.BenchmarkTcpClient localhost 8080</code></p>
  * <p>results=Iterations: 1000000 | Avg Time: 28.966 micros | Min Time: 11.0 micros | Max Time: 340.0 micros | 75% = [avg: 26.232 micros, max: 29.0 micros] | 90% = [avg: 27.38 micros, max: 37.0 micros] | 99% = [avg: 28.618 micros, max: 50.0 micros] | 99.9% = [avg: 28.907 micros, max: 80.0 micros] | 99.99% = [avg: 28.957 micros, max: 102.0 micros] | 99.999% = [avg: 28.964 micros, max: 133.0 micros]</p>
  */
 public class BenchmarkTcpClient extends AbstractClient
@@ -64,8 +64,7 @@ public class BenchmarkTcpClient extends AbstractClient
     messages = getInt("messages", 1000000);
     readBuffer = ByteBuffer.allocate(msgSize);
     sendBuffer = ByteBuffer.allocate(msgSize);
-    eventLoop = getBoolean("optimizedEventLoop", false)?
-            new OptimizedEventLoop("OptimizedEventLoop") :new DefaultEventLoop("DefaultEventLoop");
+    eventLoop = DefaultEventLoop.createEventLoop("ClientEventLoop");
     final Thread eventLoopThread = eventLoop.start();
     eventLoop.connect(new InetSocketAddress(host, port), this);
     eventLoopThread.join();

--- a/src/test/java/com/datatorrent/benchmark/netlet/EchoTcpServer.java
+++ b/src/test/java/com/datatorrent/benchmark/netlet/EchoTcpServer.java
@@ -42,7 +42,7 @@ import static java.lang.Thread.sleep;
  * <a href="http://stackoverflow.com/questions/23839437/what-are-the-netty-alternatives-for-high-performance-networking">http://stackoverflow.com/questions/23839437/what-are-the-netty-alternatives-for-high-performance-networking</a>,
  * <a href="http://www.coralblocks.com/NettyBench.zip">http://www.coralblocks.com/NettyBench.zip</a> and
  * <a href="https://groups.google.com/forum/#!topic/mechanical-sympathy/fhbyMnnxmaA">https://groups.google.com/forum/#!topic/mechanical-sympathy/fhbyMnnxmaA</a>
- * <p>run: <code>java -server -XX:+PrintGCDetails -Xms2g -Xmx2g -XX:NewSize=756m -XX:MaxNewSize=756m -DdetailedBenchmarker=true -DmeasureGC=false -DmsgSize=256 -DoptimizedEventLoop=true com.datatorrent.benchmark.netlet.EchoTcpServer</code></p>
+ * <p>run: <code>java -server -XX:+PrintGCDetails -Xms2g -Xmx2g -XX:NewSize=756m -XX:MaxNewSize=756m -DdetailedBenchmarker=true -DmeasureGC=false -DmsgSize=256 com.datatorrent.benchmark.netlet.EchoTcpServer</code></p>
  * <p>results=Iterations: 1000000 | Avg Time: 14.549 micros | Min Time: 0.0 nanos | Max Time: 120.0 micros | 75% = [avg: 13.236 micros, max: 15.0 micros] | 90% = [avg: 13.716 micros, max: 18.0 micros] | 99% = [avg: 14.375 micros, max: 26.0 micros] | 99.9% = [avg: 14.502 micros, max: 53.0 micros] | 99.99% = [avg: 14.542 micros, max: 72.0 micros] | 99.999% = [avg: 14.548 micros, max: 89.0 micros]</p>
  */
 public class EchoTcpServer extends AbstractServer
@@ -52,8 +52,7 @@ public class EchoTcpServer extends AbstractServer
   private EchoTcpServer(final String host, final int port) throws IOException, InterruptedException
   {
     super();
-    final DefaultEventLoop defaultEventLoop = getBoolean("optimizedEventLoop", false)?
-            new OptimizedEventLoop("OptimizedEventLoop") : new DefaultEventLoop("DefaultEventLoop");
+    final DefaultEventLoop defaultEventLoop = DefaultEventLoop.createEventLoop("ServerEventLoop");
     final Thread eventLoopThread = defaultEventLoop.start();
     defaultEventLoop.start(host, port, this);
     eventLoopThread.join();

--- a/src/test/java/com/datatorrent/benchmark/netlet/EchoTcpServer.java
+++ b/src/test/java/com/datatorrent/benchmark/netlet/EchoTcpServer.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (C) 2015 DataTorrent, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datatorrent.benchmark.netlet;
+
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.datatorrent.benchmark.util.Benchmarker;
+import com.datatorrent.netlet.AbstractClient;
+import com.datatorrent.netlet.AbstractServer;
+import com.datatorrent.netlet.DefaultEventLoop;
+import com.datatorrent.netlet.EventLoop;
+import com.datatorrent.netlet.OptimizedEventLoop;
+
+import static com.datatorrent.benchmark.util.SystemUtils.getBoolean;
+import static com.datatorrent.benchmark.util.SystemUtils.getInt;
+import static java.lang.Thread.sleep;
+
+/**
+ * <p>Netlet Coral Block based Benchmark Echo Test Server</p>
+ * see: <a href="http://www.coralblocks.com/index.php/2014/04/coralreactor-vs-netty-performance-comparison">http://www.coralblocks.com/index.php/2014/04/coralreactor-vs-netty-performance-comparison</a>,
+ * <a href="http://stackoverflow.com/questions/23839437/what-are-the-netty-alternatives-for-high-performance-networking">http://stackoverflow.com/questions/23839437/what-are-the-netty-alternatives-for-high-performance-networking</a>,
+ * <a href="http://www.coralblocks.com/NettyBench.zip">http://www.coralblocks.com/NettyBench.zip</a> and
+ * <a href="https://groups.google.com/forum/#!topic/mechanical-sympathy/fhbyMnnxmaA">https://groups.google.com/forum/#!topic/mechanical-sympathy/fhbyMnnxmaA</a>
+ * <p>run: <code>java -server -XX:+PrintGCDetails -Xms2g -Xmx2g -XX:NewSize=756m -XX:MaxNewSize=756m -DdetailedBenchmarker=true -DmeasureGC=false -DmsgSize=256 -DoptimizedEventLoop=true com.datatorrent.benchmark.netlet.EchoTcpServer</code></p>
+ * <p>results=Iterations: 1000000 | Avg Time: 14.549 micros | Min Time: 0.0 nanos | Max Time: 120.0 micros | 75% = [avg: 13.236 micros, max: 15.0 micros] | 90% = [avg: 13.716 micros, max: 18.0 micros] | 99% = [avg: 14.375 micros, max: 26.0 micros] | 99.9% = [avg: 14.502 micros, max: 53.0 micros] | 99.99% = [avg: 14.542 micros, max: 72.0 micros] | 99.999% = [avg: 14.548 micros, max: 89.0 micros]</p>
+ */
+public class EchoTcpServer extends AbstractServer
+{
+  private static final Logger logger = LoggerFactory.getLogger(EchoTcpServer.class);
+
+  private EchoTcpServer(final String host, final int port) throws IOException, InterruptedException
+  {
+    super();
+    final DefaultEventLoop defaultEventLoop = getBoolean("optimizedEventLoop", false)?
+            new OptimizedEventLoop("OptimizedEventLoop") : new DefaultEventLoop("DefaultEventLoop");
+    final Thread eventLoopThread = defaultEventLoop.start();
+    defaultEventLoop.start(host, port, this);
+    eventLoopThread.join();
+  }
+
+  @Override
+  public void handleException(Exception e, EventLoop eventLoop)
+  {
+    logger.error("", e);
+    eventLoop.stop(this);
+    ((DefaultEventLoop)eventLoop).stop();
+  }
+
+  @Override
+  public ClientListener getClientConnection(SocketChannel client, final ServerSocketChannel server)
+  {
+    logger.info("{} connected.", client);
+    return new AbstractClient()
+    {
+      private final ByteBuffer buffer = ByteBuffer.allocate(getInt("msgSize", 256));
+      private final Benchmarker bench = Benchmarker.create();
+      private long start;
+
+      @Override
+      public ByteBuffer buffer()
+      {
+        buffer.clear();
+        return buffer;
+      }
+
+      @Override
+      public void handleException(Exception e, EventLoop eventLoop)
+      {
+        logger.error("", e);
+        eventLoop.stop(EchoTcpServer.this);
+      }
+
+      @Override
+      public void unregistered(SelectionKey key)
+      {
+        super.unregistered(key);
+        bench.printResults(System.out);
+      }
+
+      @Override
+      public void read(int len)
+      {
+        buffer.flip();
+        long tsReceived = buffer.getLong();
+
+        if (tsReceived > 0) {
+          bench.measure(System.nanoTime() - tsReceived);
+        } else if (tsReceived == -1) {
+          start = System.currentTimeMillis();
+          logger.info("Received the first message.");
+        } else if (tsReceived == -2) {
+          logger.info("Finished receiving messages! Overall test time: {} millis", System.currentTimeMillis() - start);
+          return;
+        } else if (tsReceived < 0) {
+          logger.error("Received bad timestamp {}", tsReceived);
+          return;
+        }
+
+        try {
+          while (!send(buffer.array())) {
+            sleep(5);
+          }
+          write();
+        }
+        catch (Exception ie) {
+          throw new RuntimeException(ie);
+        }
+      }
+    };
+  }
+
+  public static void main(String[] args)
+  {
+    int port;
+    if (args.length > 0) {
+      port = Integer.parseInt(args[0]);
+    } else {
+      port = 8080;
+    }
+
+    try {
+      new EchoTcpServer("localhost", port);
+    } catch (IOException e) {
+      logger.error("", e);
+    } catch (InterruptedException e) {
+      logger.error("", e);
+    }
+  }
+}

--- a/src/test/java/com/datatorrent/benchmark/netty/BenchmarkTcpClient.java
+++ b/src/test/java/com/datatorrent/benchmark/netty/BenchmarkTcpClient.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright (C) 2015 DataTorrent, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datatorrent.benchmark.netty;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerAdapter;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.datatorrent.benchmark.util.Benchmarker;
+
+import static com.datatorrent.benchmark.util.SystemUtils.getInt;
+
+/**
+ * <p>Netty Coral Block based Benchmark Test Client</p>
+ * see: <a href="http://www.coralblocks.com/index.php/2014/04/coralreactor-vs-netty-performance-comparison">http://www.coralblocks.com/index.php/2014/04/coralreactor-vs-netty-performance-comparison</a>,
+ * <a href="http://stackoverflow.com/questions/23839437/what-are-the-netty-alternatives-for-high-performance-networking">http://stackoverflow.com/questions/23839437/what-are-the-netty-alternatives-for-high-performance-networking</a>,
+ * <a href="http://www.coralblocks.com/NettyBench.zip">http://www.coralblocks.com/NettyBench.zip</a> and
+ * <a href="https://groups.google.com/forum/#!topic/mechanical-sympathy/fhbyMnnxmaA">https://groups.google.com/forum/#!topic/mechanical-sympathy/fhbyMnnxmaA</a>
+ * <p>run: <code>java -server -verbose:gc -Xms1g -Xmx1g -XX:NewSize=512m -XX:MaxNewSize=512m -DdetailedBenchmarker=true -DmeasureGC=false -DmsgSize=256 -Dmessages=1000000 com.datatorrent.benchmark.netlet.BenchmarkTcpClient localhost 8080</code></p>
+ * <p>results=Iterations: 1000000 | Avg Time: 30.95 micros | Min Time: 14.0 micros | Max Time: 233.0 micros | 75% = [avg: 29.173 micros, max: 31.0 micros] | 90% = [avg: 29.822 micros, max: 35.0 micros] | 99% = [avg: 30.676 micros, max: 50.0 micros] | 99.9% = [avg: 30.895 micros, max: 77.0 micros] | 99.99% = [avg: 30.941 micros, max: 102.0 micros] | 99.999% = [avg: 30.948 micros, max: 139.0 micros]</p>
+ */
+public class BenchmarkTcpClient extends ChannelHandlerAdapter
+{
+	private static final Logger logger = LoggerFactory.getLogger(BenchmarkTcpClient.class);
+
+	private int count = 0;
+  private long start;
+	private boolean warmingUp = false;
+	private boolean benchmarking = false;
+	private long tsSent;
+  private ByteBuf sendBuf;
+	private final int messages;
+  private final Benchmarker bench = Benchmarker.create();
+	private final int msgSize;
+	
+	public BenchmarkTcpClient() throws IOException
+  {
+		super();
+		this.msgSize = getInt("msgSize", 256);
+		this.messages = getInt("messages", 1000000);
+	}
+
+  @Override
+  public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)
+  {
+    // Close the connection when an exception is raised.
+    cause.printStackTrace();
+    ctx.close();
+  }
+
+  @Override
+  public void channelActive(final ChannelHandlerContext ctx)
+  {
+    logger.info("Connected. Sending the first message.");
+    start = System.currentTimeMillis();
+    warmingUp = true;
+    benchmarking = false;
+    count = 0;
+    sendBuf = ctx.alloc().buffer(msgSize);
+    send(-1, ctx); // very first message, so the other side knows we are starting...
+  }
+
+  @Override
+  public void channelInactive(final ChannelHandlerContext ctx)
+  {
+    logger.info("Disconnected. Overall test time: {} millis", System.currentTimeMillis() - start);
+  }
+
+  @Override
+  public void channelRead(ChannelHandlerContext ctx, Object msg)
+  {
+    ByteBuf buf = (ByteBuf) msg;
+    long tsReceived = buf.getLong(0);
+    buf.release();
+
+    if (tsReceived < -2) {
+      logger.error("Received bad timestamp {}", tsReceived);
+      ctx.close();
+      return;
+    } else if (tsReceived != tsSent) {
+      logger.error("Received bad timestamp {}. Sent timestamp {}", tsReceived, tsSent);
+      ctx.close();
+      return;
+    } else if (tsReceived > 0) {
+      bench.measure(System.nanoTime() - tsReceived);
+    }
+    send(ctx);
+  }
+
+  private void send(final long tsSent, final ChannelHandlerContext ctx)
+  {
+    this.tsSent = tsSent; // save to check echo msg...
+    sendBuf.clear();
+    sendBuf.writeLong(tsSent);
+    for(int i = 0; i < msgSize - 8; i++) {
+      sendBuf.writeByte((byte)'x');
+    }
+    sendBuf.retain();
+    ctx.writeAndFlush(sendBuf);
+  }
+
+  private void send(ChannelHandlerContext ctx)
+  {
+    if (warmingUp) {
+      if (++count == messages) { // done warming up...
+        logger.info("Finished warming up! Sent {} messages in {} millis", count, System.currentTimeMillis() - start);
+        warmingUp = false;
+        benchmarking = true;
+        count = 0;
+        send(System.nanoTime(), ctx); // first testing message
+      } else {
+        send(0, ctx);
+      }
+    } else if (benchmarking) {
+      if (++count == messages) {
+        logger.info("Finished sending messages! Sent {} messages.", count);
+        // send the last message to tell the client we are done...
+        send(-2, ctx);
+        bench.printResults(System.out);
+        ctx.close();
+      } else {
+        send(System.nanoTime(), ctx);
+      }
+    }
+  }
+	
+  public static void main(String[] args)
+  {
+    String host = args[0];
+    int port = Integer.parseInt(args[1]);
+    EventLoopGroup workerGroup = new NioEventLoopGroup();
+
+
+    try {
+      Bootstrap b = new Bootstrap(); // (1)
+      b.group(workerGroup); // (2)
+      b.channel(NioSocketChannel.class); // (3)
+      b.option(ChannelOption.SO_KEEPALIVE, true); // (4)
+      b.handler(new ChannelInitializer<SocketChannel>()
+      {
+        @Override
+        public void initChannel(SocketChannel ch) throws Exception
+        {
+          ch.pipeline().addLast(new BenchmarkTcpClient());
+        }
+      });
+
+      // Start the client.
+      ChannelFuture f = b.connect(host, port).sync(); // (5)
+
+      // Wait until the connection is closed.
+      f.channel().closeFuture().sync();
+    } catch (Exception e) {
+      logger.error("", e);
+    } finally {
+      workerGroup.shutdownGracefully();
+    }
+  }
+}

--- a/src/test/java/com/datatorrent/benchmark/netty/EchoTcpServer.java
+++ b/src/test/java/com/datatorrent/benchmark/netty/EchoTcpServer.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (C) 2015 DataTorrent, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datatorrent.benchmark.netty;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerAdapter;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+
+import com.datatorrent.benchmark.util.Benchmarker;
+
+/**
+ * <p>Netty Coral Block based Benchmark Echo Test Server</p>
+ * see: <a href="http://www.coralblocks.com/index.php/2014/04/coralreactor-vs-netty-performance-comparison">http://www.coralblocks.com/index.php/2014/04/coralreactor-vs-netty-performance-comparison</a>,
+ * <a href="http://stackoverflow.com/questions/23839437/what-are-the-netty-alternatives-for-high-performance-networking">http://stackoverflow.com/questions/23839437/what-are-the-netty-alternatives-for-high-performance-networking</a>,
+ * <a href="http://www.coralblocks.com/NettyBench.zip">http://www.coralblocks.com/NettyBench.zip</a> and
+ * <a href="https://groups.google.com/forum/#!topic/mechanical-sympathy/fhbyMnnxmaA">https://groups.google.com/forum/#!topic/mechanical-sympathy/fhbyMnnxmaA</a>
+ * <p>run: <code>java-server -XX:+PrintGCDetails -Xms2g -Xmx2g -XX:NewSize=756m -XX:MaxNewSize=756m -DdetailedBenchmarker=true -DmeasureGC=false -DmsgSize=256 com.datatorrent.benchmark.netlet.EchoTcpServer</code></p>
+ * <p>results=Iterations: 1000000 | Avg Time: 16.014 micros | Min Time: 0.0 nanos | Max Time: 174.0 micros | 75% = [avg: 15.07 micros, max: 16.0 micros] | 90% = [avg: 15.404 micros, max: 18.0 micros] | 99% = [avg: 15.86 micros, max: 26.0 micros] | 99.9% = [avg: 15.973 micros, max: 41.0 micros] | 99.99% = [avg: 16.009 micros, max: 74.0 micros] | 99.999% = [avg: 16.012 micros, max: 89.0 micros]</p>
+ */
+public class EchoTcpServer extends ChannelHandlerAdapter
+{
+
+	private static final Logger logger = LoggerFactory.getLogger(EchoTcpServer.class);
+
+	private final Benchmarker bench = Benchmarker.create();
+	private long start;
+
+	public EchoTcpServer() throws IOException
+  {
+		super();
+	}
+	
+  @Override
+  public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)
+  {
+      // Close the connection when an exception is raised.
+      cause.printStackTrace();
+      ctx.close();
+  }
+	
+  @Override
+  public void channelRead(ChannelHandlerContext ctx, Object msg)
+  {
+    ByteBuf buf = (ByteBuf)msg;
+
+    long tsReceived = buf.getLong(0);
+
+    if (tsReceived > 0) {
+      bench.measure(System.nanoTime() - tsReceived);
+    } else if (tsReceived == -1) {
+      start = System.currentTimeMillis();
+      logger.info("Received the first message.");
+    } else if (tsReceived == -2) {
+      logger.info("Finished receiving messages! Overall test time: {} millis", System.currentTimeMillis() - start);
+      ctx.close();
+      bench.printResults(System.out);
+      return;
+    } else if (tsReceived < 0) {
+      logger.error("Received bad timestamp {}", tsReceived);
+      ctx.close();
+      return;
+    }
+
+		ctx.writeAndFlush(msg);
+	}
+	
+	public static void main(String[] args) throws Exception
+  {
+		int port;
+		if (args.length > 0) {
+				port = Integer.parseInt(args[0]);
+		} else {
+				port = 8080;
+		}
+		
+		EventLoopGroup bossGroup = new NioEventLoopGroup();
+		EventLoopGroup workerGroup = new NioEventLoopGroup();
+		try {
+			ServerBootstrap b = new ServerBootstrap();
+			b.group(bossGroup, workerGroup).channel(NioServerSocketChannel.class)
+			        .childHandler(new ChannelInitializer<SocketChannel>() {
+				                @Override
+				                public void initChannel(SocketChannel ch) throws Exception {
+					                ch.pipeline().addLast(new EchoTcpServer());
+				                }
+			                }).option(ChannelOption.SO_BACKLOG, 128)
+			        .childOption(ChannelOption.SO_KEEPALIVE, true);
+
+			ChannelFuture f = b.bind(port).sync(); // (7)
+			f.channel().closeFuture().sync();
+		} finally {
+			workerGroup.shutdownGracefully();
+			bossGroup.shutdownGracefully();
+		}
+	}
+}

--- a/src/test/java/com/datatorrent/benchmark/util/Benchmarker.java
+++ b/src/test/java/com/datatorrent/benchmark/util/Benchmarker.java
@@ -1,0 +1,197 @@
+/**
+ * Copyright (C) 2015 DataTorrent, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datatorrent.benchmark.util;
+
+import java.io.PrintStream;
+
+/**
+ * <p>Coral Block based Benchmark</p>
+ * see: <a href="http://www.coralblocks.com/index.php/2014/04/coralreactor-vs-netty-performance-comparison">http://www.coralblocks.com/index.php/2014/04/coralreactor-vs-netty-performance-comparison</a>,
+ * <a href="http://stackoverflow.com/questions/23839437/what-are-the-netty-alternatives-for-high-performance-networking">http://stackoverflow.com/questions/23839437/what-are-the-netty-alternatives-for-high-performance-networking</a>,
+ * <a href="http://www.coralblocks.com/NettyBench.zip">http://www.coralblocks.com/NettyBench.zip</a> and
+ * <a href="https://groups.google.com/forum/#!topic/mechanical-sympathy/fhbyMnnxmaA">https://groups.google.com/forum/#!topic/mechanical-sympathy/fhbyMnnxmaA</a>
+ */
+public class Benchmarker {
+
+	private static final int DEFAULT_WARMUP = 0;
+	private static final int NUMBER_OF_DECIMALS = 3;
+	private static final long NANO_COST_ITERATIONS = 10000000L;
+
+	private long time;
+	private long count = 0;
+	private long totalTime = 0;
+	private long minTime = Long.MAX_VALUE;
+	private long maxTime = Long.MIN_VALUE;
+
+	private final int warmup;
+	private final boolean excludeNanoTimeCost;
+	private final long nanoTimeCost;
+
+	Benchmarker(final int warmup) {
+		this.warmup = warmup;
+		
+		this.excludeNanoTimeCost = SystemUtils.getBoolean("excludeNanoTimeCost", false);
+		
+		if (excludeNanoTimeCost) {
+			nanoTimeCost = calcNanoTimeCost();
+		} else {
+			nanoTimeCost = 0;
+		}
+		
+		try {
+			// initialize it here so when you measure for the first time gargage is not created...
+			Class.forName("java.lang.Math");
+		}
+		catch (final Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	public static Benchmarker create() {
+		return create(DEFAULT_WARMUP);
+	}
+	
+	public static Benchmarker create(boolean detailedBenchmarker) {
+		return create(DEFAULT_WARMUP, detailedBenchmarker);
+	}
+	
+	public static Benchmarker create(int warmup) {
+		boolean detailedBenchmarker = SystemUtils.getBoolean("detailedBenchmarker", false);
+		return create(warmup, detailedBenchmarker);
+	}
+	
+	public long getNanoTimeCost() {
+		return excludeNanoTimeCost ? nanoTimeCost : -1;
+	}
+	
+    public static long calcNanoTimeCost() {
+
+    	final long start = System.nanoTime();
+
+			for (int i = 0; i < NANO_COST_ITERATIONS; i++) {
+					System.nanoTime();
+			}
+
+			long finish = System.nanoTime();
+
+			return (finish - start) / NANO_COST_ITERATIONS;
+    }
+	
+	public static Benchmarker create(int warmup, boolean detailedBenchmarker) {
+		Benchmarker b;
+		if (detailedBenchmarker) {
+			b = new DetailedBenchmarker(warmup);
+		} else {
+			b = new Benchmarker(warmup);
+		}
+		return b;
+	}
+
+	public void reset() {
+		time = 0;
+		count = 0;
+		totalTime = 0;
+		minTime = Long.MAX_VALUE;
+		maxTime = Long.MIN_VALUE;
+	}
+
+	public void mark() {
+		time = System.nanoTime();
+	}
+
+	public long measure() {
+		if (time > 0) {
+			long lastTime = System.nanoTime() - time - nanoTimeCost;
+			lastTime = Math.max(0, lastTime);
+			final boolean counted = measure(lastTime);
+			if (counted) {
+				return lastTime;
+			}
+		}
+		return -1;
+	}
+	
+	public final boolean isWarmingUp() {
+		return warmup <= count;
+	}
+
+	public boolean measure(final long lastNanoTime) {
+		if (++count > warmup) {
+			totalTime += lastNanoTime;
+			minTime = Math.min(minTime, lastNanoTime);
+			maxTime = Math.max(maxTime, lastNanoTime);
+			return true;
+		}
+		return false;
+	}
+
+	private double avg() {
+		final long realCount = count - warmup;
+		if (realCount <= 0) {
+			return 0;
+		}
+		final double avg = ((double) totalTime / (double) realCount);
+		return Math.round(avg * 100D) / 100D;
+	}
+	
+	private static double round(double d) {
+		
+		return round(d, NUMBER_OF_DECIMALS);
+	}
+	
+	private static double round(double d, int decimals) {
+		
+		double pow = Math.pow(10, decimals);
+		
+		return ((double) Math.round(d * pow)) / pow;
+	}
+	
+	public static String convertNanoTime(double nanoTime) {
+		if (nanoTime >= 1000000L) {
+			// millis...
+			double millis = round(nanoTime / 1000000D);
+			return millis + " millis";
+		} else if (nanoTime >= 1000L) {
+			// micros...
+			double micros = round(nanoTime / 1000L);
+			return micros + " micros";
+		} else {
+			double nanos = round(nanoTime);
+			return nanos + " nanos";
+		}
+	}
+
+	public String results() {
+		final StringBuilder sb = new StringBuilder(128);
+		final long realCount = count - warmup;
+		sb.append("Iterations: ").append(realCount);
+		sb.append(" | Avg Time: ").append(convertNanoTime(avg()));
+		if (realCount > 0) {
+			sb.append(" | Min Time: ").append(convertNanoTime(minTime));
+			sb.append(" | Max Time: ").append(convertNanoTime(maxTime));
+		}
+
+		return sb.toString();
+	}
+
+	public void printResults(PrintStream out) {
+		StringBuilder results = new StringBuilder();
+		results.append("results=");
+		results.append(results());
+		out.println(results);
+	}
+
+}

--- a/src/test/java/com/datatorrent/benchmark/util/DetailedBenchmarker.java
+++ b/src/test/java/com/datatorrent/benchmark/util/DetailedBenchmarker.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (C) 2015 DataTorrent, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datatorrent.benchmark.util;
+
+import java.text.NumberFormat;
+import java.util.Arrays;
+
+import gnu.trove.map.TLongIntMap;
+import gnu.trove.map.hash.TLongIntHashMap;
+
+/**
+ * <p>Coral Block based Detailed Benchmark</p>
+ * see: <a href="http://www.coralblocks.com/index.php/2014/04/coralreactor-vs-netty-performance-comparison">http://www.coralblocks.com/index.php/2014/04/coralreactor-vs-netty-performance-comparison</a>,
+ * <a href="http://stackoverflow.com/questions/23839437/what-are-the-netty-alternatives-for-high-performance-networking">http://stackoverflow.com/questions/23839437/what-are-the-netty-alternatives-for-high-performance-networking</a>,
+ * <a href="http://www.coralblocks.com/NettyBench.zip">http://www.coralblocks.com/NettyBench.zip</a> and
+ * <a href="https://groups.google.com/forum/#!topic/mechanical-sympathy/fhbyMnnxmaA">https://groups.google.com/forum/#!topic/mechanical-sympathy/fhbyMnnxmaA</a>
+ */
+public class DetailedBenchmarker extends Benchmarker {
+	
+	private TLongIntMap results = new TLongIntHashMap(1000000);
+  private long[] times;
+	private int size;
+	
+	DetailedBenchmarker(int warmup) {
+	    super(warmup);
+    }
+	
+	@Override
+	public void reset() {
+		super.reset();
+		size = 0;
+		results.clear();
+	}
+	
+	@Override
+	public boolean measure(long lastTime) {
+		boolean counted = super.measure(lastTime);
+		if (counted) {
+      results.adjustOrPutValue(lastTime, 1, 1);
+			size++;
+		}
+		return counted;
+	}
+	
+	private String formatPercentage(double x) {
+		NumberFormat percentFormat = NumberFormat.getPercentInstance();
+		percentFormat.setMaximumFractionDigits(3);
+		return percentFormat.format(x);
+	}
+
+	private void addPercentile(StringBuilder sb, double perc) {
+		
+		if (results.isEmpty()) {
+			return;
+		}
+
+		long max = -1;
+		long x = Math.round(perc * size);
+    int count = 0;
+    long sum = 0;
+    for (long time : times) {
+      int i = results.get(time);
+      count += i;
+      sum += (i*time);
+      if (count >= x) {
+        max = time;
+        break;
+      }
+		}
+		sb.append(" | ").append(formatPercentage(perc)).append(" = [avg: ").append(convertNanoTime(sum / count)).append(", max: ").append(convertNanoTime(max)).append(']');
+	}
+	
+	@Override
+	public String results() {
+		StringBuilder sb = new StringBuilder(super.results());
+    times = results.keys();
+    Arrays.sort(times);
+
+		addPercentile(sb, 0.75D);
+		addPercentile(sb, 0.9D);
+		addPercentile(sb, 0.99D);
+		addPercentile(sb, 0.999D);
+		addPercentile(sb, 0.9999D);
+		addPercentile(sb, 0.99999D);
+		
+		return sb.toString();
+	}
+	
+}

--- a/src/test/java/com/datatorrent/benchmark/util/SystemUtils.java
+++ b/src/test/java/com/datatorrent/benchmark/util/SystemUtils.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2015 DataTorrent, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datatorrent.benchmark.util;
+
+/**
+ * <p>Coral Block based SystemUtils</p>
+ * see: <a href="http://www.coralblocks.com/index.php/2014/04/coralreactor-vs-netty-performance-comparison">http://www.coralblocks.com/index.php/2014/04/coralreactor-vs-netty-performance-comparison</a>,
+ * <a href="http://stackoverflow.com/questions/23839437/what-are-the-netty-alternatives-for-high-performance-networking">http://stackoverflow.com/questions/23839437/what-are-the-netty-alternatives-for-high-performance-networking</a>,
+ * <a href="http://www.coralblocks.com/NettyBench.zip">http://www.coralblocks.com/NettyBench.zip</a> and
+ * <a href="https://groups.google.com/forum/#!topic/mechanical-sympathy/fhbyMnnxmaA">https://groups.google.com/forum/#!topic/mechanical-sympathy/fhbyMnnxmaA</a>
+ */
+public class SystemUtils {
+	
+	public static int getInt(String name, int def) {
+		
+		String s = System.getenv(name);
+		
+		if (s == null) s = System.getProperty(name);
+		
+		if (s == null) return def;
+		
+		return Integer.parseInt(s);
+	}
+	
+	public static boolean getBoolean(String name, boolean def) {
+		
+		String s = System.getenv(name);
+		
+		if (s == null) s = System.getProperty(name);
+		
+		if (s == null) return def;
+		
+		return s.equals("true");
+	}
+}


### PR DESCRIPTION
Introduced createEventLoop factory method that encapsulates creation of concrete class. The only two supported classes for now are DefaultEventLoop and OptimizedEventLoop. By default OptimizedEventLoop is created unless com.datatorrent.netlet.disableOptimizedEventLoop property is set.  Deprecated DefaultEventLoop constructor.
