### PR TITLE
Introduced createEventLoop factory.

### DIFF
--- a/src/main/java/com/datatorrent/netlet/DefaultEventLoop.java
+++ b/src/main/java/com/datatorrent/netlet/DefaultEventLoop.java
@@ -36,6 +36,19 @@ import com.datatorrent.netlet.util.CircularBuffer;
  */
 public class DefaultEventLoop implements Runnable, EventLoop
 {
+  public static final String eventLoopPropertyName = "com.datatorrent.netlet.disableOptimizedEventLoop";
+  public static DefaultEventLoop createEventLoop(final String id) throws IOException
+  {
+    final String disableOptimizedEventLoop = System.getProperty(eventLoopPropertyName);
+    if (disableOptimizedEventLoop == null || disableOptimizedEventLoop.equalsIgnoreCase("false") || disableOptimizedEventLoop.equalsIgnoreCase("no")) {
+      return new OptimizedEventLoop(id);
+    } else {
+      @SuppressWarnings("deprecation")
+      DefaultEventLoop eventLoop = new DefaultEventLoop(id);
+      return eventLoop;
+    }
+  }
+
   public final String id;
   protected final Selector selector;
   protected final CircularBuffer<Runnable> tasks;
@@ -43,6 +56,12 @@ public class DefaultEventLoop implements Runnable, EventLoop
   private int refCount;
   private Thread eventThread;
 
+  /**
+   * @deprecated use factory method {@link #createEventLoop(String)}
+   * @param id of the event loop
+   * @throws IOException
+   */
+  @Deprecated
   public DefaultEventLoop(String id) throws IOException
   {
     this.tasks = new CircularBuffer<Runnable>(1024, 5);

--- a/src/main/java/com/datatorrent/netlet/OptimizedEventLoop.java
+++ b/src/main/java/com/datatorrent/netlet/OptimizedEventLoop.java
@@ -97,7 +97,8 @@ public class OptimizedEventLoop extends DefaultEventLoop
     }
   }
 
-  public OptimizedEventLoop(String id) throws IOException
+  @SuppressWarnings("deprecation")
+  OptimizedEventLoop(String id) throws IOException
   {
     super(id);
     try {

--- a/src/test/java/com/datatorrent/netlet/AbstractClientTest.java
+++ b/src/test/java/com/datatorrent/netlet/AbstractClientTest.java
@@ -92,15 +92,15 @@ public class AbstractClientTest
   }
 
   @SuppressWarnings("SleepWhileInLoop")
-  private void verifySendReceive(DefaultEventLoop el) throws IOException, InterruptedException
+  private void verifySendReceive(final DefaultEventLoop el, final int port) throws IOException, InterruptedException
   {
     ServerImpl si = new ServerImpl();
     ClientImpl ci = new ClientImpl();
 
     new Thread(el).start();
 
-    el.start("localhost", 5033, si);
-    el.connect(new InetSocketAddress("localhost", 5033), ci);
+    el.start("localhost", port, si);
+    el.connect(new InetSocketAddress("localhost", port), ci);
 
     ByteBuffer outboundBuffer = ByteBuffer.allocate(ClientImpl.BUFFER_CAPACITY);
     LongBuffer lb = outboundBuffer.asLongBuffer();
@@ -130,16 +130,33 @@ public class AbstractClientTest
     Assert.assertTrue(ci.read);
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void testWithDefault() throws IOException, InterruptedException
   {
-    verifySendReceive(new DefaultEventLoop("test"));
+    verifySendReceive(new DefaultEventLoop("test"), 5033);
   }
 
   @Test
   public void testWithOptimized() throws IOException, InterruptedException
   {
-    verifySendReceive(new OptimizedEventLoop("test"));
+    verifySendReceive(new OptimizedEventLoop("test"), 5034);
+  }
+
+  @Test
+  public void testCreateEventLoop() throws IOException
+  {
+    Assert.assertEquals(OptimizedEventLoop.class, DefaultEventLoop.createEventLoop("test").getClass());
+    System.setProperty(DefaultEventLoop.eventLoopPropertyName, "");
+    Assert.assertEquals(DefaultEventLoop.class, DefaultEventLoop.createEventLoop("test").getClass());
+    System.setProperty(DefaultEventLoop.eventLoopPropertyName, "false");
+    Assert.assertEquals(OptimizedEventLoop.class, DefaultEventLoop.createEventLoop("test").getClass());
+    System.setProperty(DefaultEventLoop.eventLoopPropertyName, "true");
+    Assert.assertEquals(DefaultEventLoop.class, DefaultEventLoop.createEventLoop("test").getClass());
+    System.setProperty(DefaultEventLoop.eventLoopPropertyName, "no");
+    Assert.assertEquals(OptimizedEventLoop.class, DefaultEventLoop.createEventLoop("test").getClass());
+    System.setProperty(DefaultEventLoop.eventLoopPropertyName, "yes");
+    Assert.assertEquals(DefaultEventLoop.class, DefaultEventLoop.createEventLoop("test").getClass());
   }
 
   private static final Logger logger = LoggerFactory.getLogger(AbstractClientTest.class);


### PR DESCRIPTION
Introduced createEventLoop factory method that encapsulates creation of the concrete EventLoop class. The only two supported classes for now are DefaultEventLoop and OptimizedEventLoop. By default OptimizedEventLoop is created unless com.datatorrent.netlet.disableOptimizedEventLoop property is set.  Deprecated DefaultEventLoop constructor. Added unit test for createEventLoop. Fixed bind() error in unit test by using different ports.
